### PR TITLE
Non standar job parameters caused exception

### DIFF
--- a/rocks.inspectit.releaseplugin/src/main/java/rocks/inspectit/releaseplugin/AbstractJIRAAction.java
+++ b/rocks.inspectit.releaseplugin/src/main/java/rocks/inspectit/releaseplugin/AbstractJIRAAction.java
@@ -103,7 +103,9 @@ public abstract class AbstractJIRAAction extends Builder {
 	  	}
 		if (params != null) {
 			for (ParameterValue val : params.getParameters()) {
-				variables.put(val.getName(), val.getValue().toString());
+				if (val.getValue() != null) {
+					variables.put(val.getName(), val.getValue().toString());
+				}
 			}
 		}
 		StrSubstitutor subs = new StrSubstitutor(variables);


### PR DESCRIPTION
Fixed a bug where job parameters that don't store their value in the
"value" ParameterValue, such as List Subersion Tags or other advanced
parameters, would cause the plugin to fail and, consequently, the whole
job.